### PR TITLE
Add exclude base image to snyk:docker

### DIFF
--- a/gitlabci/addon.yml
+++ b/gitlabci/addon.yml
@@ -442,6 +442,7 @@ snyk:docker:
   script:
     - |
       snyk test \
+        --exclude-base-image-vulns \
         --org="${SNYK_ORG}" \
         --project-name="${ADDON_GITHUB_REPO}" \
         --docker "registry.gitlab.com/${CI_PROJECT_PATH}/${SNYK_MONITOR_ARCH}:${CI_COMMIT_SHA}" \


### PR DESCRIPTION
## Proposed Change

I added this to my own org's ci files. This stops the test from failing on issues caused by the base image. This could help differentiate from what can and can't be fixed.

This was found in the script itself:

```bash
Pro tip: use `--exclude-base-image-vulns` to exclude from display Docker base image vulnerabilities.
```
